### PR TITLE
Fix data leaking in retrospective dataset generation

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -37,6 +37,14 @@ DATA:
       NAME: 'Service'
       START: 'ServiceStartDate'
       END: 'ServiceEndDate'
+  OTHER_TIMED_FEATURES:
+      ExpenseStartDate: ['ExpenseType', 'Expensefrequency', 'ExpenseAmount', 'IsEssential']
+      IncomeStartDate: ['IncomeType', 'MonthlyAmount']
+      HealthIssueStart: ['HealthIssue', 'HealthIssueMedicationName', 'OtherMedications', 'Diagnosed','SelfReported', 'Suspected']
+      ContributingFactorDateStart: ['ContributingFactor']
+      BehavioralRiskFactorDateStart: ['BehavioralFactor', 'Severity']
+      LifeEventStartDate: ['LifeEvent']
+      SPDAT_Date: ['TotalScore']
 
 # Neural network models
 NN:

--- a/src/horizon_search.py
+++ b/src/horizon_search.py
@@ -30,7 +30,7 @@ def horizon_search():
             results_df = results_df.append(pd.DataFrame.from_records([results]))
         results_df.insert(0, 'n', n)    # Add prediction horizon to test results
         test_metrics_df = test_metrics_df.append(results_df)    # Append results from this value of n
-    test_metrics_df.drop(test_metrics_df.columns[0],axis=1,inplace=True)    # Drop dummy first column
+    #test_metrics_df.drop(test_metrics_df.columns[0],axis=1,inplace=True)    # Drop dummy first column
 
     # Save results
     test_metrics_df.to_csv(cfg['PATHS']['HORIZON_SEARCH'], sep=',', header=True, index=False)


### PR DESCRIPTION
Although service records over the past n weeks were being removed in the dataset during preprocessing, records depicting other events in the client's life during that time frame were not accounted for. Thus, data from future events (e.g. health issues, expenses, behavioural risk factors) could be leaking into the training set, thus falsely increasing the model's predictive power. This fix allows users to specify dated features and associated event features to remove in a config file. Records associated with those dated features are set to null. For example, by setting ContributingFactorStartDate as a dated feature to remove and setting ContributingFactor as its associated event features, all records for ContributingFactor will be set to null if ContributingFactorStartDate occurs within the predictive horizon.