### PR TITLE
Option to include only SPDAT data in preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,8 @@ below.
     SPDAT data during preprocessing
   - **SPDAT_CLIENTS_ONLY**: Boolean variable indicating whether to
     include only clients who have a SPDAT in the preprocessed dataset
+  - **SPDAT_DATA_ONLY**: Boolean variable indicating whether to include
+    only answers to SPDAT questions in the preprocessed dataset
 #### NN
 - **MODEL1**: Contains definitions of configurable hyperparameters
   associated with the model architecture. The values currently in this

--- a/config.yml
+++ b/config.yml
@@ -25,7 +25,7 @@ PATHS:
 # Constants pertaining to data structure
 DATA:
   N_WEEKS: 12
-  GROUND_TRUTH_DATE: '2020-02-14'
+  GROUND_TRUTH_DATE: 'today'
   CHRONIC_THRESHOLD: 180
   FEATURES_TO_DROP_FIRST: ['OrganizationID','MovedInDate','HealthIssueMedicationName','OtherMedications','DietCatetory','FoodType',
                            'ConsentType','ClientHeightCM','EyeColour','HairColour','ProvinceOfBirth','CityOfBirth','CountryOfBirth',
@@ -60,8 +60,8 @@ DATA:
       END: 'ServiceEndDate'
   SPDAT:
     INCLUDE_SPDATS: true
-    SPDAT_CLIENTS_ONLY: true
-    SPDAT_DATA_ONLY: true
+    SPDAT_CLIENTS_ONLY: false
+    SPDAT_DATA_ONLY: false
 
 
 # Neural network models

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -447,10 +447,10 @@ def preprocess(n_weeks=None, include_gt=True, calculate_gt=True, classify_cat_fe
                                                                           train_end_date)
         if config['DATA']['SPDAT']['SPDAT_CLIENTS_ONLY']:
             df_clients = df_clients.join(spdat_df, how='inner')      # Add SPDAT data, but only take clients with SPDATs
+            if config['DATA']['SPDAT']['SPDAT_DATA_ONLY']:
+                df_clients = df_clients[list(spdat_df.columns)]  # Only features will be SPDAT questions
         else:
             df_clients = df_clients.join(spdat_df, how='left')      # Add SPDAT data for clients with SPDATs
-        if config['DATA']['SPDAT']['SPDAT_CLIENTS_ONLY']:
-            df_clients = df_clients[list(spdat_df.columns)]   # Only features will be SPDAT questions
         if classify_cat_feats:
             noncategorical_feats += noncat_spdat_feats
             sv_cat_feats += sv_cat_spdat_feats

--- a/src/data/spdat.py
+++ b/src/data/spdat.py
@@ -84,5 +84,8 @@ def get_spdat_data(spdat_path, gt_end_date):
     df_clients = df_clients.droplevel(level=1, axis='index')            # Ensure index is ClientID
     print("# of clients with SPDAT = " + str(df_clients.shape[0]))
 
-    sv_cat_feats, noncat_feats = get_spdat_feat_types(df_clients)
+    sv_cat_feats, noncat_feats = get_spdat_feat_types(df_clients)       # Classify SPDAT questions as features
+
+    # Replace "0.0" with "Unknown" for categorical features
+    df_clients[sv_cat_feats] = df_clients[sv_cat_feats].replace(to_replace=0, value='Unknown')
     return df_clients, sv_cat_feats, noncat_feats


### PR DESCRIPTION
In config.yml, the user now has the option to preprocess data using only SPDAT questions as features. Also fixed a bug whereby one-hot encoded SPDAT categorical features had an extra features for "_0.0" - changed any values of these variables to "Unknown" to prevent this from occurring. Made appropriate changes to README.