### PR TITLE
Exclusion of clients not providing consent to use their information

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,10 @@ below.
   a date with the following format: _'yyyy-mm-dd'_.
 - **CHRONIC_THRESHOLD**: Number of stays per year for a client to be
   considered chronically homeless
+- **CLIENT_EXCLUSIONS**: A list of Client IDs (integers) that specifies
+  clients who did not provide consent to be included in this project.
+  Records belonging to these clients will be automatically removed from
+  the raw dataset prior to preprocessing.
 - **FEATURES_TO_DROP_FIRST**: Features you would like to exclude
   entirely from the model. For us, this list evolved through trial and
   error. For example, after running LIME to produce prediction

--- a/config.yml
+++ b/config.yml
@@ -28,6 +28,7 @@ DATA:
   N_WEEKS: 26
   GROUND_TRUTH_DATE: 'today'
   CHRONIC_THRESHOLD: 180
+  CLIENT_EXCLUSIONS: []
   FEATURES_TO_DROP_FIRST: ['OrganizationID','MovedInDate','HealthIssueMedicationName','OtherMedications','DietCatetory','FoodType',
                            'ConsentType','ClientHeightCM','EyeColour','HairColour','ProvinceOfBirth','CityOfBirth','CountryOfBirth',
                            'ServiceProvider']

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -352,8 +352,9 @@ def preprocess(n_weeks=None, include_gt=True, calculate_gt=True, classify_cat_fe
     '''
     run_start = datetime.today()
     tqdm.pandas()
-    input_stream = open(os.getcwd() + "/config.yml", 'r')
-    config = yaml.full_load(input_stream)       # Load config data
+    config = yaml.full_load(open(os.getcwd() + "/config.yml", 'r'))       # Load config data
+
+    # Load lists of features in raw data
     categorical_feats = config['DATA']['CATEGORICAL_FEATURES']
     noncategorical_feats = config['DATA']['NONCATEGORICAL_FEATURES']
     timed_service_feats = config['DATA']['TIMED_SERVICE_FEATURES']
@@ -361,6 +362,8 @@ def preprocess(n_weeks=None, include_gt=True, calculate_gt=True, classify_cat_fe
     identifying_feats_to_drop_last = config['DATA']['IDENTIFYING_FEATURES_TO_DROP_LAST']
     timed_feats_to_drop_last = config['DATA']['TIMED_FEATURES_TO_DROP_LAST']
     GROUND_TRUTH_DURATION = 365     # In days. Set to 1 year.
+
+    # Set prediction horizon
     if n_weeks is None:
         N_WEEKS = config['DATA']['N_WEEKS']
     else:
@@ -371,6 +374,9 @@ def preprocess(n_weeks=None, include_gt=True, calculate_gt=True, classify_cat_fe
     if data_path == None:
         data_path = config['PATHS']['RAW_DATA']
     df = load_df(data_path)
+
+    # Exclude clients who did not provide consent to use their information for this project
+    df.drop(df[df['ClientID'].isin(config['DATA']['CLIENT_EXCLUSIONS'])].index, inplace=True)
 
     # Delete unwanted columns
     print("Dropping some features.")


### PR DESCRIPTION
A an attribute was added to config.yml that specifies a list of client IDs. This list is meant to specify any clients who did **not** provide consent to be included in the HIFIS AI project. Being on this list excludes a client from preprocessing and model training (assuming that conservative interpretation of the "right to not be subject to automated decision making" in the GDPR and Privacy Commissioner of Canada AI legislation/recommendations. 