### PR TITLE
F1 Score fix.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ PATHS:
   GROUND_TRUTH: 'data/processed/GroundTruth.csv'
   DATA_INFO: './data/interpretability/data_info.yml'
   MODEL_WEIGHTS: 'results/models/model.h5'
-  MODEL_TO_LOAD: 'results/models/model20200312-115408.h5'
+  MODEL_TO_LOAD: 'results/models/model.h5'
   IMAGES: 'documents/generated_images/'
   LOGS: 'results\\logs\\'
   HORIZON_SEARCH: 'results/experiments/horizon_search'

--- a/src/interpretability/cluster.py
+++ b/src/interpretability/cluster.py
@@ -95,7 +95,7 @@ def cluster_clients(k=None, save_centroids=True, save_clusters=True, explain_cen
             scaler_ct = load(cfg['PATHS']['SCALER_COL_TRANSFORMER'])
             ohe_ct_sv = load(cfg['PATHS']['OHE_COL_TRANSFORMER_SV'])
             explainer = dill.load(open(cfg['PATHS']['LIME_EXPLAINER'], 'rb'))
-            model = load_model(cfg['PATHS']['MODEL_TO_LOAD'])
+            model = load_model(cfg['PATHS']['MODEL_TO_LOAD'], compile=False)
         except FileNotFoundError as not_found_err:
             print('File "' + not_found_err.filename + 
                   '" was not found. Ensure you have trained a model and run LIME before running this script.')

--- a/src/interpretability/lime_explain.py
+++ b/src/interpretability/lime_explain.py
@@ -179,7 +179,7 @@ def setup_lime():
     dill.dump(lime_dict['EXPLAINER'], open(cfg['PATHS']['LIME_EXPLAINER'], 'wb'))    # Serialize the explainer
 
     # Load trained model's weights
-    lime_dict['MODEL'] = load_model(cfg['PATHS']['MODEL_TO_LOAD'])
+    lime_dict['MODEL'] = load_model(cfg['PATHS']['MODEL_TO_LOAD'], compile=False)
     return lime_dict
 
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -44,7 +44,7 @@ def predict_and_explain_set(data_path=None, save_results=True, give_explanations
 
     # Restore the model and LIME explainer from their respective serializations
     explainer = dill.load(open(cfg['PATHS']['LIME_EXPLAINER'], 'rb'))
-    model = load_model(cfg['PATHS']['MODEL_TO_LOAD'])
+    model = load_model(cfg['PATHS']['MODEL_TO_LOAD'], compile=False)
 
     # Get the predictive horizon that this model was trained on. It's embedded within the model name.
     n_weeks = int(model._name.split('_')[1].split('-')[0])


### PR DESCRIPTION
Until recently, the model was unable to be loaded from disk when F1 Score was included as a custom metric. A simple fix (for now) is to not compile the model when loading from memory. Compilation of the model is not necessary for inference.