### PR TITLE
Updated README to state how to remove features from preprocessing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,25 @@ for all clients, given raw data from HIFIS and a trained model.
       previous times, enabling the user to compare the change in
       predictions and explanations for particular clients over time.
 
+### Exclusion of sensitive features
+Depending on your organization's circumstances, you may wish to exclude
+specific HIFIS features that you consider sensitive due to legal,
+ethical or social reasons. A simply way to ensure that a feature does
+not cause bias in the model is to avoid including it as a feature of the
+model. This project supports the exclusion of specific features by
+dropping them at the start of data preprocessing. See the below steps
+for details on how to accomplish this:
+1. Having completed steps 1-3 in [Getting Started](#getting-started),
+   open the raw HIFIS data (i.e. _"HIFIS_Clients.csv"_), which should
+   be within the _data/raw/_ folder.
+2. Features that the model will be trained on correspond to the column
+   names of this file. Decide which features you wish to exclude from
+   model training. Take note of these column names.
+3. Open [config.yml](config.yml) for editing. Add the column names that
+   you decided on during step 2 to the list of features detailed in the
+   _FEATURES_TO_DROP_FIRST_ field of the _DATA_ section of
+   [config.yml](config.yml) (for more info see [Project Config](#data)).
+
 ### Client Clustering Experiment (Using K-Prototypes)
 We were interested in investigating whether HIFIS client data could be
 clustered. Since HIFIS consists of numerical and categorical data and in

--- a/config.yml
+++ b/config.yml
@@ -29,7 +29,7 @@ PATHS:
 # Constants pertaining to data structure
 DATA:
   N_WEEKS: 26
-  GROUND_TRUTH_DATE: '2020-05-04'   # Set to either 'today' or a past date with format 'yyyy-mm-dd'
+  GROUND_TRUTH_DATE: 'today'   # Set to either 'today' or a past date with format 'yyyy-mm-dd'
   CHRONIC_THRESHOLD: 180
   CLIENT_EXCLUSIONS: []
   FEATURES_TO_DROP_FIRST: ['OrganizationID','MovedInDate','HealthIssueMedicationName','OtherMedications','DietCatetory','FoodType',


### PR DESCRIPTION
To reduce bias in the model, one may wish to exclude sensitive features that are present in the HIFIS database from the training of the model. Functionality was already in place, but specific documentation was required.