### PR TITLE
Fixed bug in preprocessing of TotalScore

### DIFF
--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -173,7 +173,7 @@ def remove_n_weeks(df, train_end_date, dated_feats, cat_feats):
     # Set features with dated events occurring after the maximum training set date to null
     for feat in dated_feats:
         idxs_to_update = df[df[feat] > train_end_date].index.tolist()
-        dated_feats[feat] = [f for f in dated_feats[feat] if f in cat_feats]
+        dated_feats[feat] = [f for f in dated_feats[feat] if f in df.columns]
         df.loc[idxs_to_update, dated_feats[feat]] = np.nan
 
     # Update client age


### PR DESCRIPTION
It was noticed that there was a bug in the calculation of TotalScore. Clients who had their first SPDAT taken within the time horizon had this score included in their preprocessed data record. Since the client hadn't had a SPDAT yet as of the preprocessing date (N weeks ago from calculation of ground truth), their TotalScore should have been -1 (i.e. non-existent).