### PR TITLE
Cross validation experiments

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -64,6 +64,7 @@ DATA:
       NAME: 'Service'
       START: 'ServiceStartDate'
       END: 'ServiceEndDate'
+  KFOLDS: 10
   TIME_SERIES:
     TIME_STEP: 30                        # In days
     T_X: 6                               # Length of time series input sequence
@@ -103,7 +104,7 @@ TRAIN:
   TRAIN_SPLIT: 0.9
   VAL_SPLIT: 0.05
   TEST_SPLIT: 0.05
-  EPOCHS: 1
+  EPOCHS: 300
   BATCH_SIZE: 1024
   POS_WEIGHT: 0.5
   IMB_STRATEGY: 'class_weight'            # One of {'class_weight', 'random_oversample', 'smote', 'adasyn'}

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -759,7 +759,7 @@ def preprocess(cfg=None, n_weeks=None, include_gt=True, calculate_gt=True, class
 
         # Vectorize the multi-valued categorical features
         print("Vectorizing multi-valued categorical features.")
-        df, vec_mv_cat_feats, mv_cat_values = vec_multi_value_cat_features(df, mv_cat_feats, cfg, load_ct)
+        df, vec_mv_cat_feats = vec_multi_value_cat_features(df, mv_cat_feats, cfg, load_ct)
 
         # Amalgamate rows to have one entry per client
         print("Aggregating the dataframe.")

--- a/src/train.py
+++ b/src/train.py
@@ -1,5 +1,5 @@
 import random
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import train_test_split, KFold
 from sklearn.preprocessing import StandardScaler
 from sklearn.compose import ColumnTransformer
 from joblib import dump
@@ -385,10 +385,88 @@ def random_hparam_search(cfg, data, callbacks, log_dir):
     return
 
 
+def kfold_cross_validation(cfg, callbacks, base_log_dir):
+    '''
+    Perform k-fold cross-validation for the HIFIS-MLP model. Data is saved in CSV format to the
+    "/results/experiments" folder.
+    :param cfg: Project config dict
+    :param callbacks: List of Keras callbacks
+    :param base_log_dir: base log directory for TensorBoard logs
+    '''
+    df_ohe = pd.read_csv(cfg['PATHS']['PROCESSED_OHE_DATA'])
+    data_info = yaml.full_load(open(cfg['PATHS']['DATA_INFO'], 'r'))
+    metadata = {'N_WEEKS': data_info['N_WEEKS']}
+    data = {}
+    data['METADATA'] = metadata
+    noncat_features = data_info['NON_CAT_FEATURES']  # Noncategorical features to be scaled
+
+    k = cfg['DATA']['KFOLDS']     # i.e. "k" for nested cross validation
+    val_split = 1.0 / k
+    train_split = 1.0 - 2.0 / k     # Let val set be same size as test set
+
+    metrics_list = cfg['TRAIN']['METRIC_PREFERENCE']
+    metrics_df = pd.DataFrame(np.zeros((k + 1, len(metrics_list) + 1)), columns=['Fold'] + metrics_list)
+    metrics_df['Fold'] = list(range(1, k + 1)) + ['mean']
+
+    df_ohe.drop('ClientID', axis=1, inplace=True)     # Anonymize clients
+    noncat_feat_idxs = [df_ohe.columns.get_loc(c) for c in noncat_features if c in df_ohe]
+    Y = np.array(df_ohe.pop('GroundTruth'))
+    X = np.array(df_ohe)
+
+    k_fold = KFold(n_splits=k, shuffle=True)
+    row_idx = 0
+    for train_indices, test_indices in k_fold.split(df_ohe):
+        X_train = X[train_indices]
+        Y_train = Y[train_indices]
+        X_test = X[test_indices]
+        Y_test = Y[test_indices]
+
+        random_state = np.random.randint(0, high=1000)
+        relative_val_split = val_split / (train_split + val_split)  # Calculate fraction of train set to be used for validation
+        X_train, X_val, Y_train, Y_val = train_test_split(X_train, Y_train, test_size=relative_val_split,
+                                                         random_state=random_state)
+
+        # Normalize numerical data and save the scaler for prediction.
+        col_trans_scaler = ColumnTransformer(transformers=[('col_trans_ordinal', StandardScaler(), noncat_feat_idxs)],
+                                             remainder='passthrough')
+        data['X_train'] = col_trans_scaler.fit_transform(X_train)  # Only fit train data to prevent data leakage
+        data['X_val'] = col_trans_scaler.transform(X_val)
+        data['X_test'] = col_trans_scaler.transform(X_test)
+        data['Y_train'] = Y_train
+        data['Y_val'] = Y_val
+        data['Y_test'] = Y_test
+
+        cur_callbacks = callbacks.copy()
+        cur_date = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+        if base_log_dir is not None:
+            log_dir = base_log_dir + cur_date
+            cur_callbacks.append(TensorBoard(log_dir=log_dir, histogram_freq=1))
+
+        # Train the model and evaluate performance on test set
+        new_model, test_metrics = train_model(cfg, data, cur_callbacks)
+        for metric in test_metrics:
+            if metric in metrics_df.columns:
+                metrics_df[metric][row_idx] = test_metrics[metric]
+        row_idx += 1
+
+        # Log test set results and images
+        if base_log_dir is not None:
+            log_test_results(cfg, new_model, data, test_metrics, log_dir)
+
+    # Record mean test set results
+    for metric in metrics_list:
+        metrics_df[metric][k] = metrics_df[metric].mean()
+
+    # Save results
+    experiment_path = cfg['PATHS']['EXPERIMENTS'] + 'kFoldCV' + cur_date + '.csv'
+    metrics_df.to_csv(experiment_path, columns=metrics_df.columns, index_label=False, index=False)
+    return
+
+
 def nested_cross_validation(cfg, callbacks, base_log_dir):
     '''
-    Perform nested cross-validation with day-forward chaining on time series data. Data is saved in CSV format to the
-    results/experiments/ folder.
+    Perform nested cross-validation with day-forward chaining for the HIFIS-RNN-MLP model. Data is saved in CSV format
+    to the results/experiments/ folder.
     :param cfg: Project config dict
     :param callbacks: List of Keras callbacks
     :param base_log_dir: base log directory for TensorBoard logs
@@ -397,7 +475,7 @@ def nested_cross_validation(cfg, callbacks, base_log_dir):
     num_folds = cfg['DATA']['TIME_SERIES']['FOLDS']     # i.e. "k" for nested cross validation
     metrics_list = cfg['TRAIN']['METRIC_PREFERENCE']
     metrics_df = pd.DataFrame(np.zeros((num_folds + 1, len(metrics_list) + 1)), columns=['Fold'] + metrics_list)
-    metrics_df['Fold'] = list(range(num_folds)) + ['mean']
+    metrics_df['Fold'] = list(range(1, num_folds + 1)) + ['mean']
 
     # Train a model k times with different folds
     for i in range(num_folds):
@@ -420,8 +498,7 @@ def nested_cross_validation(cfg, callbacks, base_log_dir):
 
     # Record mean test set results
     for metric in metrics_list:
-        h = metrics_df[metric].mean()
-        metrics_df[metric][num_folds] = h
+        metrics_df[metric][num_folds] = metrics_df[metric].mean()
 
     # Save results
     experiment_path = cfg['PATHS']['EXPERIMENTS'] + 'nestedCV' + cur_date + '.csv'
@@ -512,6 +589,8 @@ def train_experiment(cfg=None, experiment='single_train', save_weights=True, wri
         base_log_dir = cfg['PATHS']['LOGS'] + "training\\" if write_logs else None
         if cfg['TRAIN']['MODEL_DEF'] == 'hifis_rnn_mlp':
             nested_cross_validation(cfg, callbacks, base_log_dir)   # If time series data, do nested CV
+        else:
+            kfold_cross_validation(cfg, callbacks, base_log_dir)    # If not time series data, do k-fold CV
     else:
         if experiment == 'multi_train':
             base_log_dir = cfg['PATHS']['LOGS'] + "training\\" if write_logs else None


### PR DESCRIPTION
Cross validation experiments were implemented for both models as training experiments. Specifically:
- _HIFIS-MLP:_ K-fold cross validation was implemented as a training experiment
- _HIFIS-RNN-MLP:_ nested cross validation with day-forward chaining was implemented as a training experiment
In both cases, the test set metrics for each fold and their averages across folds are saved to a CSV file in _/results/experiments_ 