### PR TITLE
Fixed saving of cluster centroids for time series data

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -149,9 +149,9 @@ PREDICTION:
 
 # Data clustering
 K-PROTOTYPES:
-  K: 5
-  N_RUNS: 30
-  N_JOBS: 1
+  K: 4
+  N_RUNS: 15
+  N_JOBS: 5
   K_MIN: 2
   K_MAX: 20
   EXPERIMENT: 'cluster_clients'               # One of {'cluster_clients', 'silhouette_analysis'}

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -782,7 +782,7 @@ def preprocess(cfg=None, n_weeks=None, include_gt=True, calculate_gt=True, class
     # Include SPDAT data
     if cfg['DATA']['SPDAT']['INCLUDE_SPDATS'] and cfg['TRAIN']['MODEL_DEF'] != 'hifis_rnn_mlp':
         print("Adding SPDAT questions as features.")
-        train_end_date = pd.to_datetime(cfg['DATA']['GROUND_TRUTH_DATE']) - timedelta(days=(n_weeks * 7))
+        train_end_date = pd.to_datetime(cfg['DATA']['GROUND_TRUTH_DATE']) - timedelta(days=(N_WEEKS * 7))
         spdat_df, sv_cat_spdat_feats, noncat_spdat_feats = get_spdat_data(cfg['PATHS']['RAW_SPDAT_DATA'],
                                                                           train_end_date)
         if cfg['DATA']['SPDAT']['SPDAT_CLIENTS_ONLY']:

--- a/src/interpretability/cluster.py
+++ b/src/interpretability/cluster.py
@@ -75,7 +75,11 @@ def cluster_clients(k=None, save_centroids=True, save_clusters=True, explain_cen
         clusters_df.set_index('ClientID')
 
     # Get centroids of clusters
-    cluster_centroids = np.concatenate((k_prototypes.cluster_centroids_[0], k_prototypes.cluster_centroids_[1]), axis=1)
+    cluster_centroids = np.zeros((k_prototypes.cluster_centroids_[0].shape[0],
+                                  k_prototypes.cluster_centroids_[0].shape[1] + k_prototypes.cluster_centroids_[1].shape[1]))
+    cluster_centroids[:, noncat_feat_idxs] = k_prototypes.cluster_centroids_[0]     # Numerical features
+    cluster_centroids[:, cat_feat_idxs] = k_prototypes.cluster_centroids_[1]        # Categorical features
+    #cluster_centroids = np.concatenate((k_prototypes.cluster_centroids_[0], k_prototypes.cluster_centroids_[1]), axis=1)
 
     # Scale noncategorical features of the centroids back to original range
     centroid_noncat_feats = cluster_centroids[:, noncat_feat_idxs]
@@ -124,8 +128,9 @@ def cluster_clients(k=None, save_centroids=True, save_clusters=True, explain_cen
 
     # Predict and explain the cluster centroids
     if explain_centroids:
-        NUM_SAMPLES = cfg['LIME']['NUM_SAMPLES']
-        NUM_FEATURES = cfg['LIME']['NUM_FEATURES']
+        model_def = cfg['TRAIN']['MODEL_DEF'].upper()
+        NUM_SAMPLES = cfg['LIME'][model_def]['NUM_SAMPLES']
+        NUM_FEATURES = cfg['LIME'][model_def]['NUM_FEATURES']
         exp_rows = []
         explanations = []
         print('Creating explanations for cluster centroids.')


### PR DESCRIPTION
Saving of cluster centroids was broken for categorical and numerical features in preprocessed examples. A simple fix was made to correct this. Default number of clusters was updated to 4, following a silhouette analysis conducted on time series preprocessed data. Also, a small variable identifier mistake was rectified in calculation of SPDAT features during preprocessing.