### PR TITLE
Column transformers loaded if preprocessing in inference mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ category_encoders==2.1.0
 numpy==1.17.4
 tqdm==4.40.2
 kmodes==0.10.2
+h5py==2.10.0


### PR DESCRIPTION
An issues with column transformers was encountered after running the inference pipeline in deployment. It turns out that a new column transformer was being created for multi-valued categorical variables whenever preprocessing was executed. As a result, if the values present in the HIFIS database necessitated new one-hot multi-valued categorical features, the preprocessed examples may have been incompatible with previously trained models that were trained on examples vectorized using different column transformer mappings. A flag was added to the time series data computation function in preprocessing that loads column transformers in the inference case.