### PR TITLE
Infer VM fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,7 +999,7 @@ _src/_ folder. If you plan on using the Azure machine learning pipelines
 defined in the _azure/_ folder, there are a few steps you will need to
 follow first:
 1. Obtain an active Azure subscription.
-2. Ensure you have installed the _azureml-sdk_ and _azureml_widgets_ pip packages.
+2. Ensure you have installed the latest version of the _azureml-sdk_ and _azureml_widgets_ pip packages.
 3. In the [Azure portal](http://portal.azure.com/), create a resource
    group.
 4. In the [Azure portal](http://portal.azure.com/), create a machine

--- a/azure/inference_pipeline.ipynb
+++ b/azure/inference_pipeline.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,9 +41,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "\n\"round_trip_load_all()\" has been removed, use\n\n  yaml = YAML()\n  yaml.load(...)\n\ninstead of file \"/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/conda_dependencies.py\", line 131\n\n                self._conda_dependencies = ruamel.yaml.round_trip_load(base_stream)\n\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 5\u001b[0m\n\u001b[1;32m      2\u001b[0m ws \u001b[38;5;241m=\u001b[39m Workspace\u001b[38;5;241m.\u001b[39mfrom_config(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m./ws_config.json\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# Set workspace's environment\u001b[39;00m\n\u001b[0;32m----> 5\u001b[0m env \u001b[38;5;241m=\u001b[39m \u001b[43mEnvironment\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfrom_pip_requirements\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mHIFIS_env\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfile_path\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m./../requirements.txt\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      6\u001b[0m env\u001b[38;5;241m.\u001b[39mpython\u001b[38;5;241m.\u001b[39mconda_dependencies\u001b[38;5;241m.\u001b[39madd_pip_package(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mazureml-core\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      7\u001b[0m env\u001b[38;5;241m.\u001b[39mpython\u001b[38;5;241m.\u001b[39mconda_dependencies\u001b[38;5;241m.\u001b[39madd_pip_package(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msendgrid\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/environment.py:1069\u001b[0m, in \u001b[0;36mEnvironment.from_pip_requirements\u001b[0;34m(name, file_path)\u001b[0m\n\u001b[1;32m   1058\u001b[0m \u001b[38;5;129m@staticmethod\u001b[39m\n\u001b[1;32m   1059\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mfrom_pip_requirements\u001b[39m(name, file_path):\n\u001b[1;32m   1060\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Create an environment object created from a pip requirements file.\u001b[39;00m\n\u001b[1;32m   1061\u001b[0m \n\u001b[1;32m   1062\u001b[0m \u001b[38;5;124;03m    :param name: The environment name.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1067\u001b[0m \u001b[38;5;124;03m    :rtype: azureml.core.environment.Environment\u001b[39;00m\n\u001b[1;32m   1068\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 1069\u001b[0m     env \u001b[38;5;241m=\u001b[39m \u001b[43mEnvironment\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1070\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mopen\u001b[39m(file_path) \u001b[38;5;28;01mas\u001b[39;00m req_file:\n\u001b[1;32m   1071\u001b[0m         env\u001b[38;5;241m.\u001b[39mpython\u001b[38;5;241m.\u001b[39mconda_dependencies\u001b[38;5;241m.\u001b[39mset_pip_requirements(req_file\u001b[38;5;241m.\u001b[39mread()\u001b[38;5;241m.\u001b[39msplitlines())\n",
+      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/environment.py:768\u001b[0m, in \u001b[0;36mEnvironment.__init__\u001b[0;34m(self, name, **kwargs)\u001b[0m\n\u001b[1;32m    766\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname \u001b[38;5;241m=\u001b[39m name\n\u001b[1;32m    767\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mversion \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m--> 768\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpython \u001b[38;5;241m=\u001b[39m \u001b[43mPythonSection\u001b[49m\u001b[43m(\u001b[49m\u001b[43m_skip_defaults\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_skip_defaults\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    769\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdocker \u001b[38;5;241m=\u001b[39m DockerSection(_skip_defaults\u001b[38;5;241m=\u001b[39m_skip_defaults)\n\u001b[1;32m    770\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mspark \u001b[38;5;241m=\u001b[39m SparkSection(_skip_defaults\u001b[38;5;241m=\u001b[39m_skip_defaults)\n",
+      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/environment.py:110\u001b[0m, in \u001b[0;36mPythonSection.__init__\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    108\u001b[0m options\u001b[38;5;241m.\u001b[39mupdate(kwargs)\n\u001b[1;32m    109\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m options[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_skip_defaults\u001b[39m\u001b[38;5;124m\"\u001b[39m]:\n\u001b[0;32m--> 110\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconda_dependencies \u001b[38;5;241m=\u001b[39m \u001b[43mCondaDependencies\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    112\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_initialized \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n",
+      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/conda_dependencies.py:131\u001b[0m, in \u001b[0;36mCondaDependencies.__init__\u001b[0;34m(self, conda_dependencies_file_path, _underlying_structure)\u001b[0m\n\u001b[1;32m    126\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    127\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m resource_stream(\n\u001b[1;32m    128\u001b[0m         BASE_PROJECT_MODULE,\n\u001b[1;32m    129\u001b[0m         BASE_PROJECT_FILE_RELATIVE_PATH\n\u001b[1;32m    130\u001b[0m     ) \u001b[38;5;28;01mas\u001b[39;00m base_stream:\n\u001b[0;32m--> 131\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_conda_dependencies \u001b[38;5;241m=\u001b[39m \u001b[43mruamel\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43myaml\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mround_trip_load\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbase_stream\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    132\u001b[0m         base_stream\u001b[38;5;241m.\u001b[39mclose()\n\u001b[1;32m    134\u001b[0m CondaDependencies\u001b[38;5;241m.\u001b[39m_validate_yaml(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_conda_dependencies)\n",
+      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/ruamel/yaml/main.py:1127\u001b[0m, in \u001b[0;36mround_trip_load\u001b[0;34m(stream, version, preserve_quotes)\u001b[0m\n\u001b[1;32m   1117\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mround_trip_load\u001b[39m(\n\u001b[1;32m   1118\u001b[0m     stream: StreamTextType,\n\u001b[1;32m   1119\u001b[0m     version: Optional[VersionType] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m   1120\u001b[0m     preserve_quotes: Optional[\u001b[38;5;28mbool\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m   1121\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Any:\n\u001b[1;32m   1122\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   1123\u001b[0m \u001b[38;5;124;03m    Parse the first YAML document in a stream\u001b[39;00m\n\u001b[1;32m   1124\u001b[0m \u001b[38;5;124;03m    and produce the corresponding Python object.\u001b[39;00m\n\u001b[1;32m   1125\u001b[0m \u001b[38;5;124;03m    Resolve only basic YAML tags.\u001b[39;00m\n\u001b[1;32m   1126\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 1127\u001b[0m     \u001b[43merror_deprecation\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mround_trip_load_all\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mload\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/ruamel/yaml/main.py:1037\u001b[0m, in \u001b[0;36merror_deprecation\u001b[0;34m(fun, method, arg, comment)\u001b[0m\n\u001b[1;32m   1035\u001b[0m s \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m   1036\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m sys\u001b[38;5;241m.\u001b[39mversion_info \u001b[38;5;241m<\u001b[39m (\u001b[38;5;241m3\u001b[39m, \u001b[38;5;241m10\u001b[39m):\n\u001b[0;32m-> 1037\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAttributeError\u001b[39;00m(s)\n\u001b[1;32m   1038\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m   1039\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAttributeError\u001b[39;00m(s, name\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m)\n",
+      "\u001b[0;31mAttributeError\u001b[0m: \n\"round_trip_load_all()\" has been removed, use\n\n  yaml = YAML()\n  yaml.load(...)\n\ninstead of file \"/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/conda_dependencies.py\", line 131\n\n                self._conda_dependencies = ruamel.yaml.round_trip_load(base_stream)\n\n"
+     ]
+    }
+   ],
    "source": [
     "# Get reference to the workspace\n",
     "ws = Workspace.from_config(\"./ws_config.json\")\n",
@@ -111,8 +129,8 @@
    "outputs": [],
    "source": [
     "# Define some constants\n",
-    "CT_NAME = \"ds3v2-infer\"          # Name of our compute cluster\n",
-    "VM_SIZE = \"STANDARD_DS3_V2\"      # Specify the Azure VM for execution of our pipeline\n",
+    "CT_NAME = \"ds12v2-infer\"          # Name of our compute cluster\n",
+    "VM_SIZE = \"STANDARD_DS12_V2\"      # Specify the Azure VM for execution of our pipeline\n",
     "MIN_NODES = 0                    # Min number of compute nodes in cluster\n",
     "MAX_NODES = 3                    # Max number of compute nodes in cluster\n",
     "\n",
@@ -263,9 +281,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8 - AzureML",
    "language": "python",
-   "name": "python3"
+   "name": "python38-azureml"
   },
   "language_info": {
    "codemirror_mode": {
@@ -277,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/azure/inference_pipeline.ipynb
+++ b/azure/inference_pipeline.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,6 +28,7 @@
     "from azureml.core.compute import ComputeTarget, AmlCompute\n",
     "from azureml.core.compute_target import ComputeTargetException\n",
     "from azureml.core.environment import Environment\n",
+    "from azureml.core.conda_dependencies import CondaDependencies\n",
     "from azureml.core.runconfig import RunConfiguration\n",
     "import shutil"
    ]
@@ -41,32 +42,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "\n\"round_trip_load_all()\" has been removed, use\n\n  yaml = YAML()\n  yaml.load(...)\n\ninstead of file \"/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/conda_dependencies.py\", line 131\n\n                self._conda_dependencies = ruamel.yaml.round_trip_load(base_stream)\n\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[2], line 5\u001b[0m\n\u001b[1;32m      2\u001b[0m ws \u001b[38;5;241m=\u001b[39m Workspace\u001b[38;5;241m.\u001b[39mfrom_config(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m./ws_config.json\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# Set workspace's environment\u001b[39;00m\n\u001b[0;32m----> 5\u001b[0m env \u001b[38;5;241m=\u001b[39m \u001b[43mEnvironment\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfrom_pip_requirements\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mHIFIS_env\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfile_path\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m./../requirements.txt\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      6\u001b[0m env\u001b[38;5;241m.\u001b[39mpython\u001b[38;5;241m.\u001b[39mconda_dependencies\u001b[38;5;241m.\u001b[39madd_pip_package(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mazureml-core\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      7\u001b[0m env\u001b[38;5;241m.\u001b[39mpython\u001b[38;5;241m.\u001b[39mconda_dependencies\u001b[38;5;241m.\u001b[39madd_pip_package(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msendgrid\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/environment.py:1069\u001b[0m, in \u001b[0;36mEnvironment.from_pip_requirements\u001b[0;34m(name, file_path)\u001b[0m\n\u001b[1;32m   1058\u001b[0m \u001b[38;5;129m@staticmethod\u001b[39m\n\u001b[1;32m   1059\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mfrom_pip_requirements\u001b[39m(name, file_path):\n\u001b[1;32m   1060\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Create an environment object created from a pip requirements file.\u001b[39;00m\n\u001b[1;32m   1061\u001b[0m \n\u001b[1;32m   1062\u001b[0m \u001b[38;5;124;03m    :param name: The environment name.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1067\u001b[0m \u001b[38;5;124;03m    :rtype: azureml.core.environment.Environment\u001b[39;00m\n\u001b[1;32m   1068\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 1069\u001b[0m     env \u001b[38;5;241m=\u001b[39m \u001b[43mEnvironment\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1070\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mopen\u001b[39m(file_path) \u001b[38;5;28;01mas\u001b[39;00m req_file:\n\u001b[1;32m   1071\u001b[0m         env\u001b[38;5;241m.\u001b[39mpython\u001b[38;5;241m.\u001b[39mconda_dependencies\u001b[38;5;241m.\u001b[39mset_pip_requirements(req_file\u001b[38;5;241m.\u001b[39mread()\u001b[38;5;241m.\u001b[39msplitlines())\n",
-      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/environment.py:768\u001b[0m, in \u001b[0;36mEnvironment.__init__\u001b[0;34m(self, name, **kwargs)\u001b[0m\n\u001b[1;32m    766\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname \u001b[38;5;241m=\u001b[39m name\n\u001b[1;32m    767\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mversion \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m--> 768\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpython \u001b[38;5;241m=\u001b[39m \u001b[43mPythonSection\u001b[49m\u001b[43m(\u001b[49m\u001b[43m_skip_defaults\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_skip_defaults\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    769\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdocker \u001b[38;5;241m=\u001b[39m DockerSection(_skip_defaults\u001b[38;5;241m=\u001b[39m_skip_defaults)\n\u001b[1;32m    770\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mspark \u001b[38;5;241m=\u001b[39m SparkSection(_skip_defaults\u001b[38;5;241m=\u001b[39m_skip_defaults)\n",
-      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/environment.py:110\u001b[0m, in \u001b[0;36mPythonSection.__init__\u001b[0;34m(self, **kwargs)\u001b[0m\n\u001b[1;32m    108\u001b[0m options\u001b[38;5;241m.\u001b[39mupdate(kwargs)\n\u001b[1;32m    109\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m options[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_skip_defaults\u001b[39m\u001b[38;5;124m\"\u001b[39m]:\n\u001b[0;32m--> 110\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconda_dependencies \u001b[38;5;241m=\u001b[39m \u001b[43mCondaDependencies\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    112\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_initialized \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n",
-      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/conda_dependencies.py:131\u001b[0m, in \u001b[0;36mCondaDependencies.__init__\u001b[0;34m(self, conda_dependencies_file_path, _underlying_structure)\u001b[0m\n\u001b[1;32m    126\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    127\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m resource_stream(\n\u001b[1;32m    128\u001b[0m         BASE_PROJECT_MODULE,\n\u001b[1;32m    129\u001b[0m         BASE_PROJECT_FILE_RELATIVE_PATH\n\u001b[1;32m    130\u001b[0m     ) \u001b[38;5;28;01mas\u001b[39;00m base_stream:\n\u001b[0;32m--> 131\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_conda_dependencies \u001b[38;5;241m=\u001b[39m \u001b[43mruamel\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43myaml\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mround_trip_load\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbase_stream\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    132\u001b[0m         base_stream\u001b[38;5;241m.\u001b[39mclose()\n\u001b[1;32m    134\u001b[0m CondaDependencies\u001b[38;5;241m.\u001b[39m_validate_yaml(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_conda_dependencies)\n",
-      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/ruamel/yaml/main.py:1127\u001b[0m, in \u001b[0;36mround_trip_load\u001b[0;34m(stream, version, preserve_quotes)\u001b[0m\n\u001b[1;32m   1117\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mround_trip_load\u001b[39m(\n\u001b[1;32m   1118\u001b[0m     stream: StreamTextType,\n\u001b[1;32m   1119\u001b[0m     version: Optional[VersionType] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m   1120\u001b[0m     preserve_quotes: Optional[\u001b[38;5;28mbool\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m   1121\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Any:\n\u001b[1;32m   1122\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   1123\u001b[0m \u001b[38;5;124;03m    Parse the first YAML document in a stream\u001b[39;00m\n\u001b[1;32m   1124\u001b[0m \u001b[38;5;124;03m    and produce the corresponding Python object.\u001b[39;00m\n\u001b[1;32m   1125\u001b[0m \u001b[38;5;124;03m    Resolve only basic YAML tags.\u001b[39;00m\n\u001b[1;32m   1126\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 1127\u001b[0m     \u001b[43merror_deprecation\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mround_trip_load_all\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mload\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/anaconda/envs/azureml_py38/lib/python3.8/site-packages/ruamel/yaml/main.py:1037\u001b[0m, in \u001b[0;36merror_deprecation\u001b[0;34m(fun, method, arg, comment)\u001b[0m\n\u001b[1;32m   1035\u001b[0m s \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m   1036\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m sys\u001b[38;5;241m.\u001b[39mversion_info \u001b[38;5;241m<\u001b[39m (\u001b[38;5;241m3\u001b[39m, \u001b[38;5;241m10\u001b[39m):\n\u001b[0;32m-> 1037\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAttributeError\u001b[39;00m(s)\n\u001b[1;32m   1038\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m   1039\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAttributeError\u001b[39;00m(s, name\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m)\n",
-      "\u001b[0;31mAttributeError\u001b[0m: \n\"round_trip_load_all()\" has been removed, use\n\n  yaml = YAML()\n  yaml.load(...)\n\ninstead of file \"/anaconda/envs/azureml_py38/lib/python3.8/site-packages/azureml/core/conda_dependencies.py\", line 131\n\n                self._conda_dependencies = ruamel.yaml.round_trip_load(base_stream)\n\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Get reference to the workspace\n",
     "ws = Workspace.from_config(\"./ws_config.json\")\n",
     "\n",
+    "# Get list of requirements\n",
+    "reqs = open(\"./../requirements.txt\", 'r').read().splitlines()\n",
+    "\n",
     "# Set workspace's environment\n",
+    "#conda_deps = CondaDependencies.create(python_version='3.7.16', pip_packages=reqs)\n",
+    "# env = Environment(name=\"HIFIS_env\")\n",
+    "# env.python.conda_dependencies = conda_deps\n",
+    "# for req in reqs:\n",
+    "#     env.python.conda_dependencies.add_pip_package(req)\n",
     "env = Environment.from_pip_requirements(name = \"HIFIS_env\", file_path = \"./../requirements.txt\")\n",
     "env.python.conda_dependencies.add_pip_package(\"azureml-core\")\n",
     "env.python.conda_dependencies.add_pip_package(\"sendgrid\")\n",
@@ -225,7 +216,7 @@
     "published_pipeline = inference_run.publish_pipeline(\n",
     "     name=\"HIFIS-RNN-MLP Inference Pipeline\",\n",
     "     description=\"Azure ML Pipeline that runs model inference on all clients in HIFIS database and computes LIME explanations\",\n",
-    "     version=\"1.0\")"
+    "     version=\"1.1\")"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,13 @@ xgboost==1.3.3
 tqdm==4.40.2
 imbalanced_learn==0.6.1
 pandas==0.25.3
-dill==0.3.0
+dill==0.3.8
 lime==0.1.1.37
 scipy==1.4.1
 tensorflow_gpu==2.4.0
 tensorboard==2.4.1
-matplotlib==3.1.1
+matplotlib==3.3.3
 joblib==0.14.1
 scikit-learn==0.22.1
 h5py==2.10.0
+protobuf==3.20


### PR DESCRIPTION
- increased inference VM size on Azure ML
- bumped `dill` version to 0.3.8 load `LIMEExplainer` that was produced using this version of `dill` in an old Python 3.7 environment. This is necessary because Azure Compute environments utilize Python 3.8